### PR TITLE
Added script to reload release notes with the contents of bp directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get update \
         zlib1g-dev \
         libldap2-dev \
         libssl-dev \
-        wget
+        wget \
+        jq
 
 # See http://wiki.nginx.org/InstallOptions
 RUN mkdir /var/log/nginx \
@@ -51,6 +52,6 @@ COPY resources/configuration/ /resources/configuration/
 COPY resources/release_note/ /resources/release_note/
 COPY resources/scripts/ /resources/scripts/
 COPY templates/configuration/ /templates/configuration/
-RUN chmod +x /resources/scripts/entrypoint.sh
+RUN chmod +x /resources/scripts/*
 
 CMD ["/resources/scripts/entrypoint.sh"]

--- a/resources/scripts/entrypoint.sh
+++ b/resources/scripts/entrypoint.sh
@@ -4,6 +4,9 @@ set -e
 cp -R /resources/configuration/* /etc/nginx/
 cp -R /resources/release_note/* /usr/share/nginx/html/
 
+# Auto populate the release note page with the blueprints
+/resources/scripts/reload_release_notes.sh
+
 # Copy and replace tokens
 perl -p -i -e 's/###([^#]+)###/defined $ENV{$1} ? $ENV{$1} : $&/eg' < "/templates/configuration/nginx.conf" 2> /dev/null 1> "/etc/nginx/nginx.conf"
 

--- a/resources/scripts/reload_release_notes.sh
+++ b/resources/scripts/reload_release_notes.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Script to reload plugins.json with all the release-notes pages, that are
+# available in the usr/share/nginx/html/bp folder.
+
+# Set up initial variables
+release_note=/usr/share/nginx/html
+release_note_folder=${release_note}/bp
+n=0;
+
+# Loop trough the files and add each of them to the webpage
+shopt -s nullglob
+for f in ${release_note_folder}/*-release-note.htm*
+do
+  this_path=${release_note_folder}/$f
+  this_file=${this_path##*/}
+  cat ${release_note}/plugins.json | jq ".blueprints[$n] = {\"url\": \"bp/$this_file\"}" > /tmp/plugins.json.new
+  mv /tmp/plugins.json.new ${release_note}/plugins.json
+  n=$((n+1))
+done


### PR DESCRIPTION
Script will be deployed each time the container is started and load all files that match the pattern *-release-note.htm* in to plugins.json. It can also be started manually via docker exec proxy /resources/scripts/reload_release_notes.sh

https://github.com/Accenture/adop-nginx/issues/2