### PR TITLE
Missing header information added to the jenkins configuration block

### DIFF
--- a/resources/configuration/sites-enabled/tools-context.conf
+++ b/resources/configuration/sites-enabled/tools-context.conf
@@ -56,6 +56,7 @@ server {
 
     location /jenkins {
         proxy_pass http://jenkins:8080;
+    	proxy_set_header Host $host;
     }
 
     location /sonar {

--- a/resources/configuration/sites-enabled/tools-context.conf
+++ b/resources/configuration/sites-enabled/tools-context.conf
@@ -56,7 +56,7 @@ server {
 
     location /jenkins {
         proxy_pass http://jenkins:8080;
-    	proxy_set_header Host $host;
+        proxy_set_header Host $host;
     }
 
     location /sonar {


### PR DESCRIPTION
Missing header information added to the jenkins configuration block to fix the reverse proxy configuration issues with jenkins.