### PR TITLE
Fixed EOF for Docker Registry

### DIFF
--- a/resources/configuration/sites-available/registry.conf
+++ b/resources/configuration/sites-available/registry.conf
@@ -1,16 +1,16 @@
 server {
   listen 443;
   server_name ~^registry*;
-  server_tokens off; 
+  server_tokens off;
 
   auth_ldap "Forbidden";
   auth_ldap_servers adop;
-  
+
   client_max_body_size 0;
 
   ssl on;
-  ssl_certificate /etc/nginx/ssl/fullchain.pem;
-  ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+  ssl_certificate /etc/nginx/ssl/registry_fullchain.pem;
+  ssl_certificate_key /etc/nginx/ssl/registry_privkey.pem;
 
   ssl_ciphers "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
@@ -18,11 +18,20 @@ server {
   ssl_session_cache shared:SSL:10m;
   ssl_session_timeout 5m;
 
-  access_log  /var/log/nginx/registry_access.log;
-  error_log   /var/log/nginx/registry_error.log;
+  access_log  /var/log/nginx/access.log logstash;
 
-    
-  location / {
+  chunked_transfer_encoding on;
+
+  add_header 'Docker-Distribution-Api-Version' 'registry/2.0' always;
+
+  location /v2/ {
+
+    # Do not allow connections from docker 1.5 and earlier
+    # docker pre-1.6.0 did not properly set the user agent on ping, catch "Go *" user agents
+    if ($http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*\$" ) {
+      return 404;
+    }
+
     gzip off;
 
     proxy_read_timeout      300;


### PR DESCRIPTION
- Fixed EOF error while "docker push"
- Added "registry_" prefix for SSL certificates names configuration
- Configuration of "access_log" via LogStash as any other services in ADOP