### PR TITLE
Removed htpasswd file as LDAP is used for user authentication

### DIFF
--- a/resources/configuration/htpasswd
+++ b/resources/configuration/htpasswd
@@ -1,2 +1,0 @@
-john.smith:$apr1$mQWUQA8f$8wVkbLFSRFi1SVW2/qc1i.
-paul.daugherty:$apr1$mQWUQA8f$8wVkbLFSRFi1SVW2/qc1i.


### PR DESCRIPTION
Removed htpasswd resources file because
- it has hardcoded HTTP basic auth credentials
- the current vhost configuration uses LDAP for authentication