### PR TITLE
Increase client max body size to 1G

### DIFF
--- a/resources/configuration/sites-enabled/tools-context.conf
+++ b/resources/configuration/sites-enabled/tools-context.conf
@@ -75,6 +75,7 @@ server {
     }
 
     location /nexus {
+        client_max_body_size 1G;
         proxy_pass  http://nexus:8081/nexus;
     }
 


### PR DESCRIPTION
Hi,

as discussed on #37, this PR increases the client_max_body_size for Nexus to 1G. 