### PR TITLE
Refactoring; html folder creation added - fixes container start failure (target not found: /usr/share/nging/html)

### DIFF
--- a/resources/configuration/sites-enabled/service-extension/service-extension.conf.template
+++ b/resources/configuration/sites-enabled/service-extension/service-extension.conf.template
@@ -1,3 +1,3 @@
 location /<service-name>{
-   proxy_pass  http://<service-container>:<port>
+   proxy_pass  http://<service-container>:<port>;
 }

--- a/resources/configuration/sites-enabled/tools-context.conf
+++ b/resources/configuration/sites-enabled/tools-context.conf
@@ -96,6 +96,6 @@ server {
         proxy_redirect off;
         proxy_pass http://ldap-phpadmin;
     }
-    include /etc/nginx/sites-enabled/service-extension/*.conf;
 
+    include /etc/nginx/sites-enabled/service-extension/*.conf;
 }

--- a/resources/scripts/entrypoint.sh
+++ b/resources/scripts/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 cp -R /resources/configuration/* /etc/nginx/
-cp -R /resources/release_note/* /usr/share/nginx/html/
+mkdir -p /usr/share/nginx/html/ && cp -R /resources/release_note/* /usr/share/nginx/html/
 
 # Auto populate the release note page with the blueprints
 /resources/scripts/reload_release_notes.sh


### PR DESCRIPTION
Hi team,
@anton-kasperovich @nickdgriffin @SachinKSingh28 


Please, find a bugfix/refactoring update.

Also, kindly create next minor update tag "0.4.0" as there were no new tags since August 2016 and master branch is stable at this point. Validated on AWS quickstart and on-prem SWARM

_P.S> If 0.4.0 on master is not possible due to any concern, at least add the 0.3.1 with "resources/scripts/entrypoint.sh" change. Container failure is annoying._

Thank you.