### PR TITLE
Ldaps and https support + windows fixes + sonarqube navbar fix + kibana status fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: bash
+
+sudo: required
+services:
+  - docker
+
+script:
+  - docker build -t adop-nginx .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 0.1.2 - 2017-08-28
 ## Added
+- Redirection fixes for gerrit and jenkins when proxy is setup with ssl
+
+## 0.1.2 - 2017-08-28
+## Added
 - Support for https
 
 ## 0.1.1 - 2017-08-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.1.2 - 2017-08-28
+## Added
+- Support for https
+
 ## 0.1.1 - 2017-08-25
 ## Added
 - Support for ldaps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.1.1 - 2017-08-25
+## Added
+- Support for ldaps
+
 ## 0.1.0 - 2016-02-01
 ## Added
 - First release

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,13 @@ RUN apt-get update \
         libldap2-dev \
         libssl-dev \
         wget \
-        jq
+        jq \
+        dos2unix
 
 # See http://wiki.nginx.org/InstallOptions
 RUN mkdir /var/log/nginx \
     && mkdir -p /etc/nginx/sites-enabled \
+    && mkdir -p /usr/share/nginx/html \
     && cd ~ \
     && git clone https://github.com/kvspb/nginx-auth-ldap.git \
     && git clone https://github.com/nginx/nginx.git \
@@ -53,5 +55,9 @@ COPY resources/release_note/ /resources/release_note/
 COPY resources/scripts/ /resources/scripts/
 COPY templates/configuration/ /templates/configuration/
 RUN chmod +x /resources/scripts/*
+# Fixes for builds on windows machines
+# See https://confluence.atlassian.com/kb/starting-service-on-linux-throws-a-no-such-file-or-directory-error-794203722.html
+RUN dos2unix /resources/scripts/* \
+    && sed -i -e 's/\r//g' /etc/init.d/nginx
 
 CMD ["/resources/scripts/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM ubuntu:14.04
 MAINTAINER Robert Northard, <robert.a.northard>
 
 ENV NGINX_VERSION 1.8.0
+ENV NGINX_SSL off
+ENV NGINX_PORT 80
+ENV LDAP_PROTOCOL ldap
 
 ############## nginx setup ##############
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ The nginx configuration is externalised and stored the 'resources' directory.
 
 Runtime configuration can be provided using environment variables:
 
-* NGINX_PORT, 80 or 443 (for ssl)
-* NGINX_SSL, on or off
-* LDAP_PROTOCOL, ldap or ldaps
+* NGINX_PORT, 80(default) or 443 (for ssl)
+* NGINX_SSL, off(default) or on
+* LDAP_PROTOCOL, ldap(default) or ldaps
 * LDAP_SERVER, the LDPA URI, i.e. ldap-host:389
 * LDAP_USERNAME, the LDAP BASE_DN
 * LDAP_PASSWORD, the password to use connecting to LDAP service using the provided username 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-#Supported tags and respective Dockerfile links
+# Supported tags and respective Dockerfile links
 
 - [`0.1.0`, `0.1.0` (*0.1.0/Dockerfile*)](https://github.com/Accenture/adop-nginx/blob/master/Dockerfile.md)
+
+# Build Status
+
+[![Build Status](https://travis-ci.org/Accenture/adop-nginx.svg?branch=master)](https://travis-ci.org/Accenture/adop-nginx)
 
 # What is adop-nginx?
 
@@ -26,6 +30,7 @@ The nginx configuration is externalised and stored the 'resources' directory.
 
 Runtime configuration can be provided using environment variables:
 
+* LDAP_PROTOCOL, ldap or ldaps
 * LDAP_SERVER, the LDPA URI, i.e. ldap-host:389
 * LDAP_USERNAME, the LDAP BASE_DN
 * LDAP_PASSWORD, the password to use connecting to LDAP service using the provided username 
@@ -37,7 +42,7 @@ Runtime configuration can be provided using environment variables:
 # License
 Please view [licence information](LICENCE.md) for the software contained on this image.
 
-#Supported Docker versions
+# Supported Docker versions
 
 This image is officially supported on Docker version 1.9.1.
 Support for older versions (down to 1.6) is provided on a best-effort basis.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The nginx configuration is externalised and stored the 'resources' directory.
 
 Runtime configuration can be provided using environment variables:
 
+* NGINX_PORT, 80 or 443 (for ssl)
+* NGINX_SSL, on or off
 * LDAP_PROTOCOL, ldap or ldaps
 * LDAP_SERVER, the LDPA URI, i.e. ldap-host:389
 * LDAP_USERNAME, the LDAP BASE_DN
@@ -38,6 +40,31 @@ Runtime configuration can be provided using environment variables:
 * LDAP_GROUP_ATTRIBUTE, LDAP object field attribute the defines group appartenence. 
 * LDAP_USER_ID_ATTRIBUTE, LDAP object field attribute the defines the user identifier. 
 * LDAP_USER_OBJECT_CLASS, LDAP user object class
+
+## SSL configuration
+If you have certificates, set `NGINX_PORT` to `443` and `NGINX_SSL` to `on` and add your certificates to the volume under ssl directory as `host.crt` and `host.key`:
+
+```
+# Assuming host.crt and host.key are in the current working directory, perform the following steps
+$ docker volume inspect nginx_config
+[
+    {
+        "Driver": "local",
+        "Labels": null,
+        "Mountpoint": "/u01/appl/docker/volumes/nginx_config/_data",
+        "Name": "nginx_config",
+        "Options": {},
+        "Scope": "local"
+    }
+]
+
+$ ls "/u01/appl/docker/volumes/nginx_config/_data"
+fastcgi.conf          fastcgi_params          koi-utf  mime.types          naxsi_core.rules  naxsi-ui.conf.1.4.1  nginx.conf.default  scgi_params          sites-available  ssl           uwsgi_params.default
+fastcgi.conf.default  fastcgi_params.default  koi-win  mime.types.default  naxsi.rules       nginx.conf           proxy_params        scgi_params.default  sites-enabled    uwsgi_params  win-utf
+
+$ cp host* /u01/appl/docker/volumes/nginx_config/_data/ssl/
+$ docker restart proxy
+```
 
 # License
 Please view [licence information](LICENCE.md) for the software contained on this image.

--- a/resources/configuration/sites-enabled/service-extension/service-extension.conf.template
+++ b/resources/configuration/sites-enabled/service-extension/service-extension.conf.template
@@ -1,3 +1,3 @@
 location /<service-name>{
-   proxy_pass  http://<service-container>:<port>
+   proxy_pass  http://<service-container>:<port>;
 }

--- a/resources/configuration/sites-enabled/tools-context.conf
+++ b/resources/configuration/sites-enabled/tools-context.conf
@@ -60,7 +60,7 @@ server {
         proxy_set_header Host $host;
     }
 
-    location /sonar {
+    location ^~ /sonar {
         proxy_pass http://sonar:9000/sonar;
     }
 

--- a/resources/configuration/sites-enabled/tools-context.conf
+++ b/resources/configuration/sites-enabled/tools-context.conf
@@ -42,6 +42,14 @@ server {
         proxy_pass         http://kibana:5601;
     }
 
+    location = /status {
+        proxy_pass         http://kibana:5601;
+    }
+
+     location ~ /plugins/kibana/.* {
+        proxy_pass         http://kibana:5601;
+    }
+
     location = /api/status {
         proxy_pass         http://kibana:5601;
     }

--- a/resources/configuration/sites-enabled/tools-context.conf
+++ b/resources/configuration/sites-enabled/tools-context.conf
@@ -96,6 +96,6 @@ server {
         proxy_redirect off;
         proxy_pass http://ldap-phpadmin;
     }
-    include /etc/nginx/sites-enabled/service-extension/*.conf;
 
+    include /etc/nginx/sites-enabled/service-extension/*.conf;
 }

--- a/resources/scripts/entrypoint.sh
+++ b/resources/scripts/entrypoint.sh
@@ -2,13 +2,13 @@
 set -e
 
 cp -R /resources/configuration/* /etc/nginx/
-cp -R /resources/release_note/* /usr/share/nginx/html/
+mkdir -p /usr/share/nginx/html/ && cp -R /resources/release_note/* /usr/share/nginx/html/
 
 # Auto populate the release note page with the blueprints
 /resources/scripts/reload_release_notes.sh
 
 # Copy and replace tokens
-perl -p -i -e 's/###([^#]+)###/defined $ENV{$1} ? $ENV{$1} : $&/eg' < "/templates/configuration/nginx.conf" 2> /dev/null 1> "/etc/nginx/nginx.conf"
+perl -p -i -e 's/###([^#]+)###/defined $ENV{$1} ? $ENV{$1} : ""/eg' < "/templates/configuration/nginx.conf" 2> /dev/null 1> "/etc/nginx/nginx.conf"
 
 # wait for all downstream services to be up and running
 # This is a temporary solution that allows NGINX to wait for all dependencies and after start, this should be removed when 

--- a/resources/scripts/entrypoint.sh
+++ b/resources/scripts/entrypoint.sh
@@ -9,6 +9,7 @@ mkdir -p /usr/share/nginx/html/ && cp -R /resources/release_note/* /usr/share/ng
 
 # Copy and replace tokens
 perl -p -i -e 's/###([^#]+)###/defined $ENV{$1} ? $ENV{$1} : ""/eg' < "/templates/configuration/nginx.conf" 2> /dev/null 1> "/etc/nginx/nginx.conf"
+perl -p -i -e 's/###([^#]+)###/defined $ENV{$1} ? $ENV{$1} : "$1 must be defined"/eg' < "/templates/configuration/sites-enabled/tools-context.conf" 2> /dev/null 1> "/etc/nginx/sites-enabled/tools-context.conf"
 
 # wait for all downstream services to be up and running
 # This is a temporary solution that allows NGINX to wait for all dependencies and after start, this should be removed when 

--- a/templates/configuration/nginx.conf
+++ b/templates/configuration/nginx.conf
@@ -29,10 +29,10 @@ http {
         # LDAP Settings
         ##
         ldap_server adop{
-          url "ldap://###LDAP_SERVER###/###LDAP_USER_BASE_DN###?###LDAP_USER_ID_ATTRIBUTE###?sub?(objectClass=###LDAP_USER_OBJECT_CLASS###)";
+          url "###LDAP_PROTOCOL###://###LDAP_SERVER###/###LDAP_USER_BASE_DN###?###LDAP_USER_ID_ATTRIBUTE###?sub?(objectClass=###LDAP_USER_OBJECT_CLASS###)";
           binddn "###LDAP_USERNAME###";
           binddn_passwd "###LDAP_PASSWORD###";
-          group_attribute ###LDAP_GROUP_ATTRIBUTE###;
+          group_attribute "###LDAP_GROUP_ATTRIBUTE###";
           group_attribute_is_dn on;
           require valid_user;
           satisfy all;

--- a/templates/configuration/sites-enabled/tools-context.conf
+++ b/templates/configuration/sites-enabled/tools-context.conf
@@ -1,6 +1,10 @@
 server {
-    listen       80;
+    listen       ###NGINX_PORT###;
     server_name  ~^[0-9]*;
+
+    ssl    ###NGINX_SSL###;
+    ssl_certificate    /etc/nginx/ssl/host.crt;
+    ssl_certificate_key    /etc/nginx/ssl/host.key;
 
     access_log /var/log/nginx/access.log logstash;
 
@@ -25,7 +29,6 @@ server {
         proxy_set_header   Host $host;
     }
 
-
     location /kibana/status {
         proxy_pass         http://kibana:5601/status;
     }
@@ -46,7 +49,7 @@ server {
         proxy_pass         http://kibana:5601;
     }
 
-     location ~ /plugins/kibana/.* {
+    location ~ /plugins/kibana/.* {
         proxy_pass         http://kibana:5601;
     }
 
@@ -72,7 +75,7 @@ server {
         proxy_pass http://sonar:9000/sonar;
     }
 
- location ~ (/sensu/|/socket.io/) {
+    location ~ (/sensu/|/socket.io/) {
         proxy_pass  http://sensu-uchiwa:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/templates/configuration/sites-enabled/tools-context.conf
+++ b/templates/configuration/sites-enabled/tools-context.conf
@@ -64,11 +64,15 @@ server {
     location /gerrit {
         client_max_body_size 512m;
         proxy_pass  http://gerrit:8080;
+        proxy_set_header  X-Forwarded-For $remote_addr;
+        proxy_set_header  Host $host;
     }
 
     location /jenkins {
         proxy_pass http://jenkins:8080;
         proxy_set_header Host $host;
+        proxy_read_timeout  90;
+        proxy_redirect      http:// $scheme://;
     }
 
     location ^~ /sonar {


### PR DESCRIPTION
# Summary

* Added options to specify ldap protocol
* Added configurable options to enable https on nginx
* Added fixes for container builds on Windows hosts
* Fixed cleanup of not used ldap variables in nginx config (was testing integration with enterprise ldap where I didn't use all vars defined in adop docker-compose and nginx was failing due to improper substitution of variables via perl) 

See: https://github.com/Accenture/adop-nginx/pull/29 
* Kibana status page is now working
* Sonarqube navbar is working with  sonarqube version 5.6.2

What I changed in docker-compose for testing:

* Used my own image
* Added NGINX_PORT, NGINX_SSL and LDAP_PROTOCOL variables

```

proxy:
  container_name: proxy
  restart: always
  image: lumaks/adop-nginx:official
  #image: accenture/adop-nginx:0.3.1
  #build: ../images/docker-nginx/
  net: ${CUSTOM_NETWORK_NAME}
  ports:
    - "80:80"
    - "443:443"
  environment:
    - "constraint:tier==public"
    - "NGINX_PORT=80"
    - "NGINX_SSL=off"
    - "LDAP_PROTOCOL=ldap"
    - "LDAP_SERVER=${LDAP_SERVER}"
    - "LDAP_USERNAME=${LDAP_ADMIN},${LDAP_FULL_DOMAIN}"
    - "LDAP_PASSWORD=${LDAP_PWD}"
    - "LDAP_USER_BASE_DN=${LDAP_USER_BASE_DN},${LDAP_FULL_DOMAIN}"
    - "LDAP_GROUP_ATTRIBUTE=member"
    - "LDAP_USER_ID_ATTRIBUTE=cn"
    - "LDAP_USER_OBJECT_CLASS=inetOrgPerson"
```

All images are running:

```
0c7ed2f91891        lumaks/adop-nginx:official           "/resources/script..."   2 minutes ago       Up 2 minutes                   0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp                                     proxy
ce7e0b42da19        accenture/adop-jenkins:0.2.6         "/entrypoint.sh"         38 minutes ago      Up 38 minutes                  8080/tcp, 0.0.0.0:50000->50000/tcp                                           jenkins
c487c1aed7a4        mysql:5.6.25                         "/entrypoint.sh my..."   38 minutes ago      Up 38 minutes                  3306/tcp                                                                     gerrit-mysql
40f5d992dbb9        selenium/hub:2.53.0                  "/opt/bin/entry_po..."   38 minutes ago      Up 38 minutes                  4444/tcp                                                                     selenium-hub
2a3eac37ed62        rabbitmq:3.5.7-management            "/docker-entrypoin..."   38 minutes ago      Up 38 minutes                  4369/tcp, 5671-5672/tcp, 15671-15672/tcp, 25672/tcp                          sensu-rabbitmq
12726c692458        sstarcher/uchiwa:0.15.0              "/bin/start"             38 minutes ago      Up 38 minutes                  3000/tcp                                                                     sensu-uchiwa
daa08a63dbed        accenture/adop-sensu:0.2.0           "/bin/start server"      38 minutes ago      Up 38 minutes                  4567/tcp                                                                     sensu-server
66e4b3e925eb        accenture/adop-ldap-ltb:0.1.0        "/etc/service/apac..."   38 minutes ago      Up 38 minutes                  80/tcp                                                                       ldap-ltb
8bb7d38407dd        redis:3.0.7                          "docker-entrypoint..."   38 minutes ago      Up 38 minutes                  6379/tcp                                                                     sensu-redis
adfa10b2cc4f        accenture/adop-ldap-phpadmin:0.1.0   "/run.sh"                38 minutes ago      Up 38 minutes                  80/tcp                                                                       ldap-phpadmin
5857bf050c08        registry:2.5.1                       "/entrypoint.sh /e..."   38 minutes ago      Restarting (1) 4 seconds ago                                                                                registry
576174ae1ec8        accenture/adop-sensu:0.2.0           "/bin/start api"         38 minutes ago      Up 38 minutes                  4567/tcp                                                                     sensu-api
b4edc46c0c2c        selenium/node-firefox:2.53.0         "/opt/bin/entry_po..."   38 minutes ago      Up 38 minutes                                                                                               selenium-node-firefox
353e9b8c408c        accenture/adop-jenkins-slave:0.1.4   "/bin/sh -c 'java ..."   38 minutes ago      Up 38 minutes                                                                                               jenkins-slave
bf8b74a60fc4        selenium/node-chrome:2.53.0          "/opt/bin/entry_po..."   38 minutes ago      Up 38 minutes                                                                                               selenium-node-chrome
1b82bb1c678a        mysql:5.6.25                         "/entrypoint.sh my..."   38 minutes ago      Up 38 minutes                  3306/tcp                                                                     sonar-mysql
f335db356c6b        accenture/adop-ldap:0.1.3            "/usr/local/bin/en..."   38 minutes ago      Up 38 minutes                  0.0.0.0:389->389/tcp                                                         ldap
ae8ae3538486        accenture/adop-nexus:0.1.3           "/usr/local/bin/ne..."   38 minutes ago      Up 38 minutes                  8081/tcp                                                                     nexus
a33ee7f8dc34        accenture/adop-sensu:0.2.0           "/bin/start client"      38 minutes ago      Up 38 minutes                  4567/tcp                                                                     sensu-client
181f22b6709d        accenture/adop-gerrit:0.1.3          "/var/gerrit/gerri..."   38 minutes ago      Up 37 minutes                  8080/tcp, 29418/tcp                                                          gerrit
bcb0f7db760d        accenture/adop-sonar:0.3.2           "/usr/local/bin/so..."   38 minutes ago      Up 38 minutes                  9000/tcp                                                                     sonar
4769a8476440        accenture/adop-logstash:0.1.0        "/docker-entrypoin..."   38 minutes ago      Up 38 minutes                  0.0.0.0:12201->12201/udp, 0.0.0.0:5000->5000/tcp, 0.0.0.0:25826->25826/udp   logstash
8677649cb4c7        elasticsearch:2.1.1                  "/docker-entrypoin..."   38 minutes ago      Up 38 minutes                  0.0.0.0:9200->9200/tcp, 9300/tcp                                             elasticsearch
a06e9d4f425c        kibana:4.3.1                         "/docker-entrypoin..."   38 minutes ago      Up 38 minutes                  0.0.0.0:5601->5601/tcp                                                       kibana
```

Platform is up
![image](https://user-images.githubusercontent.com/2006610/29719775-d7c7b364-89b7-11e7-8e99-85565d7772ba.png)
