### PR TITLE
Set LDAP protocol as env parameter. Default value: ldap.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:14.04
 MAINTAINER Robert Northard, <robert.a.northard>
 
 ENV NGINX_VERSION 1.8.0
-
+ENV LDAP_PROTOCOL ldap
 ############## nginx setup ##############
 
 RUN apt-get update \
@@ -32,11 +32,11 @@ RUN mkdir /var/log/nginx \
         --add-module=/root/nginx-auth-ldap \
         --with-http_ssl_module \
         --with-debug \
-        --conf-path=/etc/nginx/nginx.conf \ 
-        --sbin-path=/usr/sbin/nginx \ 
-        --pid-path=/var/run/nginx.pid \ 
-        --error-log-path=/var/log/nginx/error.log \ 
-        --http-log-path=/var/log/nginx/access.log \ 
+        --conf-path=/etc/nginx/nginx.conf \
+        --sbin-path=/usr/sbin/nginx \
+        --pid-path=/var/run/nginx.pid \
+        --error-log-path=/var/log/nginx/error.log \
+        --http-log-path=/var/log/nginx/access.log \
     && make install \
     && cd .. \
     && rm -rf nginx-auth-ldap \

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ adop-nginx provides Nginx with LDAP support. Nginx is a high performance reverse
       $ docker run --name <your-container-name> -dt \
         -v /resources/configuration/:/etc/nginx/:ro \
         -v /resources/release_note:/usr/share/nginx/html/:ro \
-        -v /var/log:/var/log 
+        -v /var/log:/var/log
         -p 443:443 \
         -p 80:80 \
         accenture/adop-nginx:VERSION
-        
+
 ## Configuration
 
 The nginx configuration is externalised and stored the 'resources' directory.
@@ -31,11 +31,12 @@ The nginx configuration is externalised and stored the 'resources' directory.
 Runtime configuration can be provided using environment variables:
 
 * LDAP_SERVER, the LDPA URI, i.e. ldap-host:389
+* LDAP_PROTOCOL, allowed values ldap(default)/ldaps
 * LDAP_USERNAME, the LDAP BASE_DN
-* LDAP_PASSWORD, the password to use connecting to LDAP service using the provided username 
+* LDAP_PASSWORD, the password to use connecting to LDAP service using the provided username
 * LDAP_USER_BASE_DN, the LDAP user BASE_DN
-* LDAP_GROUP_ATTRIBUTE, LDAP object field attribute the defines group appartenence. 
-* LDAP_USER_ID_ATTRIBUTE, LDAP object field attribute the defines the user identifier. 
+* LDAP_GROUP_ATTRIBUTE, LDAP object field attribute the defines group appartenence.
+* LDAP_USER_ID_ATTRIBUTE, LDAP object field attribute the defines the user identifier.
 * LDAP_USER_OBJECT_CLASS, LDAP user object class
 
 # License
@@ -49,7 +50,7 @@ Support for older versions (down to 1.6) is provided on a best-effort basis.
 # User feedback
 
 ## Documentation
-Documentation for this image is available in the [Nginx documentation page](http://nginx.org/en/docs/). 
+Documentation for this image is available in the [Nginx documentation page](http://nginx.org/en/docs/).
 Additional documentaion can be found under the [`docker-library/docs` GitHub repo](https://github.com/docker-library/docs). Be sure to familiarize yourself with the [repository's `README.md` file](https://github.com/docker-library/docs/blob/master/README.md) before attempting a pull request.
 
 ## Issues

--- a/templates/configuration/nginx.conf
+++ b/templates/configuration/nginx.conf
@@ -29,7 +29,7 @@ http {
         # LDAP Settings
         ##
         ldap_server adop{
-          url "ldap://###LDAP_SERVER###/###LDAP_USER_BASE_DN###?###LDAP_USER_ID_ATTRIBUTE###?sub?(objectClass=###LDAP_USER_OBJECT_CLASS###)";
+          url "###LDAP_PROTOCOL###://###LDAP_SERVER###/###LDAP_USER_BASE_DN###?###LDAP_USER_ID_ATTRIBUTE###?sub?(objectClass=###LDAP_USER_OBJECT_CLASS###)";
           binddn "###LDAP_USERNAME###";
           binddn_passwd "###LDAP_PASSWORD###";
           group_attribute ###LDAP_GROUP_ATTRIBUTE###;


### PR DESCRIPTION
At the moment LDAP protocol in nginx.conf is hardcoded. To avoid that I made env variable which by default is "ldap" but if there is a need to use other protocol we also can do this using this environment variable.